### PR TITLE
Support Dokku Redis

### DIFF
--- a/lib/github-forms.rb
+++ b/lib/github-forms.rb
@@ -39,7 +39,7 @@ module GithubForms
 
     def redis_url
       @redis_url ||=
-        URI.parse(ENV["REDISTOGO_URL"] || "redis://localhost:16379")
+        URI.parse(ENV["REDISTOGO_URL"] || ENV["REDIS_URL"] || "redis://localhost:16379")
     end
 
     def session_id


### PR DESCRIPTION
Given [this line](https://github.com/luxifer/dokku-redis-plugin/blob/master/commands#L104) in the foremost Dokku redis plugin, the current fetching of a Redis URL won't work.
